### PR TITLE
Fixed return code of each process and cleaning code

### DIFF
--- a/env.c
+++ b/env.c
@@ -46,16 +46,15 @@ void print_env(cmdbuf_t *cmd, char **env)
 	{
 		printf("%s\n", env[i]);
 	}
-	destroy(cmd->argv, cmd->size);
-	free(cmd);
+	drop(cmd);
 }
 
 /**
  * get_env - entry point
- * Desc: get_env function that compares strings
+ * Desc: get_env funcion that gets value of env
  * @varname: pointer char type to variable name
- * @env: double pointer to stored char
- * Return: returns pointer to new duplicate string or NULL
+ * @env: double pointer to the enviroment
+ * Return: returns pointer to the value of the variable
  */
 char *get_env(char *varname, char **env)
 {

--- a/handlers.c
+++ b/handlers.c
@@ -1,4 +1,5 @@
 #include "shell.h"
+#include <stdio.h>
 /* Functions who manage special commands, cd or exit */
 
 /**
@@ -16,11 +17,11 @@ int check_handlers(char *str)
 	if (!str)
 		return (handler_id);
 
-	if (!strcmp(str, "exit"))
+	if (eq(str, "exit"))
 		handler_id = 1;
-	else if (!strcmp(str, "cd"))
+	else if (eq(str, "cd"))
 		handler_id = 2;
-	else if (!strcmp(str, "env"))
+	else if (eq(str, "env"))
 		handler_id = 3;
 
 	return (handler_id);
@@ -43,14 +44,12 @@ void exit_handler(cmdbuf_t *cmd, int *exit_var_addr)
 	printf("exit\n");
 	if (cmd->argv[1] != NULL)
 	{
-		*exit_var_addr = char_toint(cmd->argv[1]);
-		destroy(cmd->argv, cmd->size);
-		free(cmd);
+		*exit_var_addr = 0;
+		drop(cmd);
 		return;
 	}
 	*exit_var_addr = 0;
-	destroy(cmd->argv, cmd->size);
-	free(cmd);
+	drop(cmd);
 }
 
 /**
@@ -71,15 +70,14 @@ void change_dir(cmdbuf_t *cmd)
 	{
 		err_handler = chdir(cmd->argv[1]);
 		if (err_handler < 0)
-			perror("cd");
+			perror(cmd->err_name);
 	}
 	else
 	{
 		home_ptr = get_env("HOME", cmd->env);
 		if (chdir(home_ptr) < 0)
-			printf("HOME VARIABLE DOES NOT EXIST\n");
+			perror(cmd->err_name);
 	}
 	free(home_ptr);
-	destroy(cmd->argv, cmd->size);
-	free(cmd);
+	drop(cmd);
 }

--- a/input.c
+++ b/input.c
@@ -16,7 +16,7 @@ void _signal(int n)
  * Desc: get_input function that reads stdin
  * Return: returns buffer stdin input
  */
-input_t *get_input()
+input_t *get_input(int proc_result)
 {
 	/* Buffer that contains stdin input */
 	char stack[READ_SIZE];
@@ -24,9 +24,10 @@ input_t *get_input()
 	int n;
 
 	signal(SIGINT, _signal);
+	signal(SIGPIPE, _signal);
 	n = read(STDIN_FILENO, stack, READ_SIZE);
 	if (n < 1)
-		exit(0);
+		exit(proc_result);
 	stack[n - 1] = '\0';
 	input = malloc(sizeof(input_t));
 	input->buffer = _strdup(stack);
@@ -74,4 +75,5 @@ void prompt(void)
 	sprintf(buff, "%s(%d:%d:%d)~%s(%s)\n>>> %s ",
 		KRED, i->tm_hour, i->tm_min, i->tm_sec, KBLU, curr_p, KGRN);
 	write(0, buff, _strlen(buff));
+	fflush(STDIN_FILENO);
 }

--- a/main.c
+++ b/main.c
@@ -1,6 +1,6 @@
 #include "shell.h"
 
-int run_shell(char **env);
+int run_shell(char *errname, char **env);
 
 /**
  * main - entry to main
@@ -15,8 +15,7 @@ int main(int argc, char **argv, char **env)
 	int exit_code = 0;
 
 	UNUSED(argc);
-	UNUSED(argv);
-	exit_code = run_shell(env);
+	exit_code = run_shell(argv[0], env);
 	return (exit_code);
 }
 
@@ -26,17 +25,19 @@ int main(int argc, char **argv, char **env)
  * @env: double pointer to environment variables
  * Return: returns a prompt to hsh shell v2
  */
-int run_shell(char **env)
+int run_shell(char *errname, char **env)
 {
 	int exit_call = -1;
+	int proc_result = 0;
 
 	while (exit_call == -1)
 	{
 		prompt();
 		fflush(STDIN_FILENO);
-		input_t *input = get_input();
+		input_t *input = get_input(proc_result);
 		cmdbuf_t *cmd = parse_input(input);
-
+		cmd->err_name = errname;
+		cmd->pre_alias = _strdup(cmd->argv[0]);
 		cmd->env = env;
 		parse_env(&cmd);
 		free(input->buffer);
@@ -57,7 +58,7 @@ int run_shell(char **env)
 			}
 			cmd->argv[0] = parse_alias(cmd->argv[0]);
 		}
-		forking(cmd);
+		proc_result = forking(cmd);
 	}
-	return (exit_call);
+	return (proc_result);
 }

--- a/shell.h
+++ b/shell.h
@@ -36,6 +36,8 @@ typedef struct CommandBuffer
 {
 	char **env;
 	char **argv;
+	char *err_name;
+	char *pre_alias;
 	size_t size;
 } cmdbuf_t;
 
@@ -53,12 +55,9 @@ typedef struct InputBuffer
 	size_t size;
 } input_t;
 
-/* Input handlers */
-input_t *get_input();
+input_t *get_input(int proc_result);
 cmdbuf_t *parse_input(input_t *input);
-/* Size handlers */
 size_t n_argv_allocate(input_t *input);
-/* String handlers */
 int counttok(char *buff);
 int check_handlers(char *str);
 int char_toint(char *arg);
@@ -68,6 +67,7 @@ void exit_handler(cmdbuf_t *cmd, int *exit_var_addr);
 void print_env(cmdbuf_t *cmd, char **env);
 void change_dir(cmdbuf_t *cmd);
 void parse_env(cmdbuf_t **cmd);
+void drop(cmdbuf_t *cmd);
 void prompt(void);
 int _strlen(char *s);
 char *_strcat(char *dest, char *src);
@@ -75,5 +75,5 @@ char *_strdup(char *str);
 char *parse_alias(char *exe);
 char *get_env(char *varname, char **env);
 int forking(cmdbuf_t *cmd);
-
+int eq(char *str1, char* str2);
 #endif

--- a/strings.c
+++ b/strings.c
@@ -71,27 +71,17 @@ int _strlen(char *s)
 	return (x);
 }
 
-/**
- * char_toint - entry to toint
- * Desc: char_toint function that transforms char pointer numerical
- * to integer
- * @arg: char pointer to string
- * Return: returns value int
- */
-int char_toint(char *arg)
+// compara 2 strings si son iguales 0 falso 1 verdadero
+int eq(char *str1, char* str2)
 {
-	int i, val = -1;
+	int i;
 
-	for (i = 0; i < _strlen(arg); i++)
-	{
-		if (val == -1)
-		{
-			val = ((int)arg[i] - 48);
-			continue;
-		}
-		val *= 10;
-		val += ((int)arg[i] - 48);
-	}
+	if (_strlen(str1) != _strlen(str2))
+		return (0);
+	
+	for (i = 0; i < _strlen(str1); i++)
+		if (str1[i] != str2[i])
+			return (0);
 
-	return (val);
+	return (1);
 }


### PR DESCRIPTION
```
Example of error with normal sh:

$ echo "qwerty" | /bin/sh
/bin/sh: 1: qwerty: not found
$ echo "qwerty" | /bin/../bin/sh
/bin/../bin/sh: 1: qwerty: not found
$ echo $?
127

example with our shell:

$ echo "qwerty" | ./hsh
./hsh: 1: qwerty: not found
$ echo "qwerty" | `./././hsh`
./././hsh: 1: qwerty: not found
$ echo $?
127
```
